### PR TITLE
Add extend license API action

### DIFF
--- a/Psnel_administracion.php
+++ b/Psnel_administracion.php
@@ -1979,8 +1979,21 @@ $current_tab = $_GET['tab'] ?? 'dashboard';
         function extendLicense(id) {
             const extension = prompt('¿Cuántos días adicionales desea agregar?', '30');
             if (extension && parseInt(extension) > 0) {
-                // Implementar extensión de licencia
-                alert('Función de extensión - Agregar ' + extension + ' días a licencia ID: ' + id);
+                fetch('api_admin.php?action=extend_license', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ id: id, days: parseInt(extension) })
+                })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        alert('Licencia extendida hasta ' + data.expires_at);
+                        location.reload();
+                    } else {
+                        alert('Error: ' + data.error);
+                    }
+                })
+                .catch(err => alert('Error: ' + err));
             }
         }
         

--- a/api_admin.php
+++ b/api_admin.php
@@ -248,6 +248,25 @@ switch ($action) {
         echo json_encode(["success" => false, "error" => "Activacin no encontrada."]);
     }
     break;
+
+    case "extend_license":
+    $data = json_decode(file_get_contents('php://input'), true) ?: [];
+    $license_id = (int)($data['id'] ?? $_POST['id'] ?? 0);
+    $days = (int)($data['days'] ?? $_POST['days'] ?? 0);
+    if ($license_id <= 0 || $days <= 0) {
+        http_response_code(400);
+        echo json_encode(["success" => false, "error" => "Parámetros inválidos."]);
+        exit;
+    }
+
+    $result = $licenseManager->extendLicense($license_id, $days);
+    if ($result['success']) {
+        echo json_encode($result);
+    } else {
+        http_response_code(500);
+        echo json_encode($result);
+    }
+    break;
     
     case "clear_old_logs":
     $result = $licenseManager->clearOldLogs();


### PR DESCRIPTION
## Summary
- implement `extendLicense()` in `LicenseManager.class.php`
- expose new `extend_license` endpoint in `api_admin.php`
- wire up dashboard button to call new API and reload page

## Testing
- `php` command not available so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_687005555c0883339b4644e6f61b741d